### PR TITLE
BUGFIX: PropTypes moved into its own core library.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View, ScrollView, Dimensions, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import tinycolor from 'tinycolor2';
 


### PR DESCRIPTION
Fix for #6 

PropTypes was moved into it's own library, some old documentation and samples that can be found still show importing from react. 