### PR TITLE
Change setState into callback after onScroll

### DIFF
--- a/components/PageData.js
+++ b/components/PageData.js
@@ -15,16 +15,16 @@ const PageContent = ({ children }) => (
   </View>
 );
 
-const PageData = ({ isLight, image, title, subtitle, ...rest }) => (
+const PageData = ({ isLight, image, title, subtitle, titleStyles, subtitleStyles, ...rest }) => (
   <Page {...rest}>
     <PageContent>
       <View style={styles.image}>
         {image}
       </View>
-      <Text style={{ ...styles.title, ...(isLight ? styles.titleLight : {}) }}>
+      <Text style={[styles.title, titleStyles, (isLight ? styles.titleLight : {}) ]}>
         {title}
       </Text>
-      <Text style={{ ...styles.subtitle, ...(isLight ? styles.subtitleLight : {}) }}>
+      <Text style={[styles.subtitle, subtitleStyles, (isLight ? styles.subtitleLight : {}) ]}>
         {subtitle}
       </Text>
     </PageContent>

--- a/index.js
+++ b/index.js
@@ -57,13 +57,15 @@ export default class Onboarding extends Component {
           onScroll={this.updatePosition}
           scrollEventThrottle={100}
         >
-          {pages.map(({ image, title, subtitle }, idx) => (
+          {pages.map(({ image, title, subtitle, titleStyles, subtitleStyles }, idx) => (
             <PageData
               key={idx}
               isLight={isLight}
               image={image}
               title={title}
               subtitle={subtitle}
+              titleStyles={titleStyles}
+              subtitleStyles={subtitleStyles}
               width={width}
               height={height}
             />

--- a/index.js
+++ b/index.js
@@ -32,8 +32,12 @@ export default class Onboarding extends Component {
     const { currentPage } = this.state;
     const nextPage = currentPage + 1;
     const offsetX = nextPage * width;
-    this.refs.scroll.scrollTo({ x: offsetX, animated: true });
-    this.setState({ currentPage: nextPage });
+    this.refs.scroll.scrollTo({
+      x: offsetX,
+      animated: true
+    }, () => {
+      this.setState({ currentPage: nextPage });
+    });
   };
 
   render() {


### PR DESCRIPTION
## Fix #1 

The issue is caused by onNext calling `setState` before `onScroll` is finished, causing `this.state` to get mutated multiple times.

Changing `this.setState` into a callback to be called after onScroll is completed fixes the flickering issue when onNext is called as a function (on button press).

